### PR TITLE
Add properties to LogMessage trait

### DIFF
--- a/testing/shared/src/main/scala/io/chrisdavenport/log4cats/testing/TestingLogger.scala
+++ b/testing/shared/src/main/scala/io/chrisdavenport/log4cats/testing/TestingLogger.scala
@@ -12,7 +12,12 @@ trait TestingLogger[F[_]] extends Logger[F] {
 }
 
 object TestingLogger {
-  sealed trait LogMessage
+
+  sealed trait LogMessage {
+    def message: String
+    def throwOpt: Option[Throwable]
+  }
+
   final case class TRACE(message: String, throwOpt: Option[Throwable]) extends LogMessage
   final case class DEBUG(message: String, throwOpt: Option[Throwable]) extends LogMessage
   final case class INFO(message: String, throwOpt: Option[Throwable]) extends LogMessage


### PR DESCRIPTION
Adding properties here makes it easier to assert that a given message was logged without needing to care about which level it was logged at.