### PR TITLE
Fixes a small typo in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ object MyThing {
   def doSomething[F[_]: Sync]: F[Unit] =
     Logger[F].info("Logging Start Something") *>
     Sync[F].delay(println("I could be doing anything"))
-      .attempt.flatTap{
+      .attempt.flatMap{
         case Left(e) => Logger[F].error(e)("Something Went Wrong")
         case Right(_) => Sync[F].pure(())
       }


### PR DESCRIPTION
Self-explanatory, `flatMap` was misspelled as `flatTap`