### PR TITLE
[WIP] Use iolog4s macro-based implementation of slf4j interface

### DIFF
--- a/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/LoggerMacros.scala
+++ b/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/LoggerMacros.scala
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2013-2017 Sarah Gerweck
+ * see: https://github.com/Log4s/log4s
+ *
+ * Modifications copyright (C) 2018 Lorand Szakacs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.chrisdavenport.log4cats.slf4j
+
+import scala.annotation.tailrec
+import scala.reflect.macros.{blackbox, whitebox}
+
+/** Macros that support the logging system.
+ *
+ *  See for handling call-by-name-parameters in macros
+ *  https://issues.scala-lang.org/browse/SI-5778
+ *
+ * @author Sarah Gerweck <sarah@atscale.com>
+ */
+private[slf4j] object LoggerMacros {
+
+  /** Get a logger by reflecting the enclosing class name. */
+  final def getLoggerImpl[F: c.WeakTypeTag](c: blackbox.Context)(f: c.Expr[F]) = {
+    import c.universe._
+
+    @tailrec def findEnclosingClass(sym: c.universe.Symbol): c.universe.Symbol = {
+      sym match {
+        case NoSymbol =>
+          c.abort(c.enclosingPosition, s"Couldn't find an enclosing class or module for the logger")
+        case s if s.isModule || s.isClass =>
+          s
+        case other =>
+          /* We're not in a module or a class, so we're probably inside a member definition. Recurse upward. */
+          findEnclosingClass(other.owner)
+      }
+    }
+
+    val cls = findEnclosingClass(c.internal.enclosingOwner)
+
+    assert(cls.isModule || cls.isClass, "Enclosing class is always either a module or a class")
+
+    def loggerByParam(param: c.Tree)(f: c.Expr[F]) =
+      q"new _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger(_root_.org.slf4j.LoggerFactory.getLogger(...${List(
+        param)}))($f)"
+
+    def loggerBySymbolName(s: Symbol)(f: c.Expr[F]) = {
+      def fullName(s: Symbol): String = {
+        @inline def isPackageObject = (
+          (s.isModule || s.isModuleClass)
+            && s.owner.isPackage
+            && s.name.decodedName.toString == termNames.PACKAGE.decodedName.toString
+        )
+        if (s.isModule || s.isClass) {
+          if (isPackageObject) {
+            s.owner.fullName
+          } else if (s.owner.isStatic) {
+            s.fullName
+          } else {
+            fullName(s.owner) + "." + s.name.encodedName.toString
+          }
+        } else {
+          fullName(s.owner)
+        }
+      }
+      loggerByParam(q"${fullName(s)}")(f)
+    }
+
+    def loggerByType(s: Symbol)(f: c.Expr[F]) = {
+      val typeSymbol: ClassSymbol = (if (s.isModule) s.asModule.moduleClass else s).asClass
+      val typeParams = typeSymbol.typeParams
+
+      if (typeParams.isEmpty) {
+        loggerByParam(q"classOf[$typeSymbol]")(f)
+      } else {
+        if (typeParams.exists(_.asType.typeParams.nonEmpty)) {
+          /* We have at least one higher-kinded type: fall back to by-name logger construction, as
+           * there's no simple way to declare a higher-kinded type with an "any" parameter. */
+          loggerBySymbolName(s)(f)
+        } else {
+          val typeArgs = List.fill(typeParams.length)(WildcardType)
+          val typeConstructor = tq"$typeSymbol[..${typeArgs}]"
+          loggerByParam(q"classOf[$typeConstructor]")(f)
+        }
+      }
+    }
+
+    @inline def isInnerClass(s: Symbol) =
+      s.isClass && !(s.owner.isPackage)
+
+    val instanceByName = Slf4jLogger.singletonsByName && (cls.isModule || cls.isModuleClass) || cls.isClass && isInnerClass(
+      cls
+    )
+
+    if (instanceByName) {
+      loggerBySymbolName(cls)(f)
+    } else {
+      loggerByType(cls)(f)
+    }
+  }
+
+  /** A macro context that represents a method call on a Logger instance. */
+  private[this] type LogCtx[F[_]] = whitebox.Context { type PrefixType = Slf4jLogger[F] }
+
+  /** Log a message reflectively at a given level.
+   *
+   * This is the internal workhorse method that does most of the logging for real applications.
+   *
+   * @param msg the message that the user wants to log
+   * @param error the `Throwable` that we're logging along with the message, if any
+   * @param logLevel the level of the logging
+   */
+  private[this] def reflectiveLog[F[_]](
+      c: LogCtx[F]
+  )(msg: c.Tree, error: Option[c.Expr[Throwable]], context: Seq[c.Expr[(String, String)]])(
+      logLevel: LogLevel) = {
+    import c.universe._
+
+    val logger = q"${c.prefix.tree}.logger"
+    val F = q"${c.prefix}.F"
+    val logValues = error match {
+      case None => List(msg)
+      case Some(e) => List(msg, e.tree)
+    }
+    val logExpr = q"$logger.${TermName(logLevel.methodName)}(..$logValues)"
+    val checkExpr = q"$logger.${TermName(s"is${logLevel.name}Enabled")}"
+
+    def errorIsSimple = {
+      error match {
+        case None | Some(c.Expr(Ident(_))) => true
+        case _ => false
+      }
+    }
+
+    msg match {
+      case _ if context.nonEmpty =>
+        val MDC = q"org.slf4j.MDC"
+        val Seq = q"scala.collection.Seq"
+        val backup = TermName(c.freshName("mdcBackup"))
+        q"""
+           if ($checkExpr) $F.delay {
+             val $backup = $MDC.getCopyOfContextMap
+             try {
+               for ((k, v) <- $Seq(..$context)) $MDC.put(k, v)
+               $logExpr
+             } finally {
+               if ($backup eq null) $MDC.clear()
+               else $MDC.setContextMap($backup)
+             }
+           } else $F.unit
+         """
+      case c.Expr(Literal(Constant(_))) if errorIsSimple =>
+        q"$F.delay($logExpr)"
+      case _ =>
+        q"if ($checkExpr) $F.delay($logExpr) else $F.unit"
+    }
+  }
+
+  def traceTM[F[_]](c: LogCtx[F])(t: c.Expr[Throwable])(msg: c.Tree) =
+    reflectiveLog(c)(msg, Some(t), Nil)(Trace)
+
+  def traceM[F[_]](c: LogCtx[F])(msg: c.Tree) = reflectiveLog(c)(msg, None, Nil)(Trace)
+
+  def traceCM[F[_]](c: LogCtx[F])(ctx: c.Expr[(String, String)]*)(msg: c.Tree) =
+    reflectiveLog(c)(msg, None, ctx)(Trace)
+
+  def debugTM[F[_]](c: LogCtx[F])(t: c.Expr[Throwable])(msg: c.Tree) =
+    reflectiveLog(c)(msg, Some(t), Nil)(Debug)
+
+  def debugM[F[_]](c: LogCtx[F])(msg: c.Tree) = reflectiveLog(c)(msg, None, Nil)(Debug)
+
+  def debugCM[F[_]](c: LogCtx[F])(ctx: c.Expr[(String, String)]*)(msg: c.Tree) =
+    reflectiveLog(c)(msg, None, ctx)(Debug)
+
+  def infoTM[F[_]](c: LogCtx[F])(t: c.Expr[Throwable])(msg: c.Tree) =
+    reflectiveLog(c)(msg, Some(t), Nil)(Info)
+
+  def infoM[F[_]](c: LogCtx[F])(msg: c.Tree) = reflectiveLog(c)(msg, None, Nil)(Info)
+
+  def infoCM[F[_]](c: LogCtx[F])(ctx: c.Expr[(String, String)]*)(msg: c.Tree) =
+    reflectiveLog(c)(msg, None, ctx)(Info)
+
+  def warnTM[F[_]](c: LogCtx[F])(t: c.Expr[Throwable])(msg: c.Tree) =
+    reflectiveLog(c)(msg, Some(t), Nil)(Warn)
+
+  def warnM[F[_]](c: LogCtx[F])(msg: c.Tree) = reflectiveLog(c)(msg, None, Nil)(Warn)
+
+  def warnCM[F[_]](c: LogCtx[F])(ctx: c.Expr[(String, String)]*)(msg: c.Tree) =
+    reflectiveLog(c)(msg, None, ctx)(Warn)
+
+  def errorTM[F[_]](c: LogCtx[F])(t: c.Expr[Throwable])(msg: c.Tree) =
+    reflectiveLog(c)(msg, Some(t), Nil)(Error)
+
+  def errorM[F[_]](c: LogCtx[F])(msg: c.Tree) = reflectiveLog(c)(msg, None, Nil)(Error)
+
+  def errorCM[F[_]](c: LogCtx[F])(ctx: c.Expr[(String, String)]*)(msg: c.Tree) =
+    reflectiveLog(c)(msg, None, ctx)(Error)
+}

--- a/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
@@ -1,68 +1,163 @@
+/**
+ * Copyright 2013-2017 Sarah Gerweck
+ * see: https://github.com/Log4s/log4s
+ *
+ * Modifications copyright (C) 2018 Lorand Szakacs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.chrisdavenport.log4cats.slf4j
 
-import cats.implicits._
 import cats.effect.Sync
 import io.chrisdavenport.log4cats.Logger
-import org.slf4j.{Logger => Base, LoggerFactory}
+
+import language.experimental.macros
+import org.slf4j.{Logger => JLogger}
 
 object Slf4jLogger {
 
-  def fromName[F[_]: Sync](name: String): Logger[F] = 
-    fromLogger[F](LoggerFactory.getLogger(name))
+  def create[F[_]: Sync]: Logger[F] = macro LoggerMacros.getLoggerImpl[F[_]]
+
+  def fromName[F[_]: Sync](name: String): Logger[F] =
+    new Slf4jLogger(org.slf4j.LoggerFactory.getLogger(name))
 
   def fromClass[F[_]: Sync](clazz: Class[_]): Logger[F] =
-    fromLogger[F](LoggerFactory.getLogger(clazz))
+    new Slf4jLogger(org.slf4j.LoggerFactory.getLogger(clazz))
 
-  // Do we want a macro here for reflection?
+  final val singletonsByName = true
+  final val trailingDollar = false
 
-  def fromLogger[F[_]: Sync](logger: Base): Logger[F] = new Logger[F]{
+  sealed trait LevelLogger[F[_]] extends Any {
+    def isEnabled: F[Boolean]
 
-    def isDebugEnabled: F[Boolean] = Sync[F].delay(logger.isDebugEnabled)
-    def isErrorEnabled: F[Boolean] = Sync[F].delay(logger.isErrorEnabled)
-    def isInfoEnabled: F[Boolean] = Sync[F].delay(logger.isInfoEnabled)
-    def isTraceEnabled: F[Boolean] = Sync[F].delay(logger.isTraceEnabled)
-    def isWarnEnabled: F[Boolean] = Sync[F].delay(logger.isWarnEnabled)
+    def apply(msg: => String): F[Unit]
+    def apply(t: Throwable)(msg: => String): F[Unit]
+  }
+//
+//  final class TraceLevelLogger[F[_]: Sync] private[slf4j] (val logger: JLogger)
+//      extends AnyVal
+//      with LevelLogger[F] {
+//    @inline def isEnabled: F[Boolean] = F.delay(logger.isTraceEnabled)
+//    @inline def apply(msg: => String): F[Unit] = isEnabled.flatMap {isEnabled => if(isEnabled) $F.delay($logExpr) else $F.unit
+//    @inline def apply(t: Throwable)(msg: => String) = if (isEnabled) logger.trace(msg, t)
+//  }
 
-    def debug(t: Throwable)(message: => String): F[Unit] = isDebugEnabled.ifM(
-      Sync[F].delay(logger.debug(message, t)),
-      Sync[F].unit
-    )
-    def debug(message: => String): F[Unit] = isDebugEnabled.ifM(
-      Sync[F].delay(logger.debug(message)),
-      Sync[F].unit
-    )
-    def error(t: Throwable)(message: => String): F[Unit] = isErrorEnabled.ifM(
-      Sync[F].delay(logger.error(message, t)),
-      Sync[F].unit
-    )
-    def error(message: => String): F[Unit] = isErrorEnabled.ifM(
-      Sync[F].delay(logger.error(message)),
-      Sync[F].unit
-    )
-    def info(t: Throwable)(message: => String): F[Unit] = isInfoEnabled.ifM(
-      Sync[F].delay(logger.info(message, t)),
-      Sync[F].unit
-    )
-    def info(message: => String): F[Unit] = isInfoEnabled.ifM(
-      Sync[F].delay(logger.info(message)),
-      Sync[F].unit
-    )
-    
-    def trace(t: Throwable)(message: => String): F[Unit] = isTraceEnabled.ifM(
-      Sync[F].delay(logger.trace(message, t)),
-      Sync[F].unit
-    )
-    def trace(message: => String): F[Unit] = isTraceEnabled.ifM(
-      Sync[F].delay(logger.trace(message)),
-      Sync[F].unit
-    )
-    def warn(t: Throwable)(message: => String): F[Unit] = isWarnEnabled.ifM(
-      Sync[F].delay(logger.warn(message, t)),
-      Sync[F].unit
-    )
-    def warn(message: => String): F[Unit] = isWarnEnabled.ifM(
-      Sync[F].delay(logger.warn(message)),
-      Sync[F].unit
-    )
+//  final class DebugLevelLogger private[slf4j] (val logger: JLogger)
+//      extends AnyVal
+//      with LevelLogger {
+//    @inline def isEnabled: Boolean = logger.isDebugEnabled
+//    @inline def apply(msg: => String): Unit = if (isEnabled) logger.debug(msg)
+//    @inline def apply(t: Throwable)(msg: => String): Unit = if (isEnabled) logger.debug(msg, t)
+//  }
+//
+//  final class InfoLevelLogger private[slf4j] (val logger: JLogger)
+//      extends AnyVal
+//      with LevelLogger {
+//    @inline def isEnabled: Boolean = logger.isInfoEnabled
+//    @inline def apply(msg: => String): Unit = if (isEnabled) logger.info(msg)
+//    @inline def apply(t: Throwable)(msg: => String): Unit = if (isEnabled) logger.info(msg, t)
+//  }
+//
+//  final class WarnLevelLogger private[slf4j] (val logger: JLogger)
+//      extends AnyVal
+//      with LevelLogger {
+//    @inline def isEnabled: Boolean = logger.isWarnEnabled
+//    @inline def apply(msg: => String): Unit = if (isEnabled) logger.warn(msg)
+//    @inline def apply(t: Throwable)(msg: => String): Unit = if (isEnabled) logger.warn(msg, t)
+//  }
+//
+//  final class ErrorLevelLogger private[slf4j] (val logger: JLogger)
+//      extends AnyVal
+//      with LevelLogger {
+//    @inline def isEnabled: Boolean = logger.isErrorEnabled
+//    @inline def apply(msg: => String): Unit = if (isEnabled) logger.error(msg)
+//    @inline def apply(t: Throwable)(msg: => String): Unit = if (isEnabled) logger.error(msg, t)
+//  }
+
+  /**
+    * The existance of this class is due to the in-ability of macros to
+    * override abstract methods, only methods directly.
+    *
+    * See:
+    * https://github.com/scala/scala/commit/ef979c02da887b7c56bc1da9c4eb888e92af570f
+    */
+  private[Slf4jLogger] class Slf4jLoggerDummyMacro[F[_]] extends Logger[F] {
+
+    @inline override def isTraceEnabled: F[Boolean] = ???
+
+    @inline override def isDebugEnabled: F[Boolean] = ???
+
+    @inline override def isInfoEnabled: F[Boolean] = ???
+
+    @inline override def isWarnEnabled: F[Boolean] = ???
+
+    @inline override def isErrorEnabled: F[Boolean] = ???
+
+    override def trace(t: Throwable)(msg: => String): F[Unit] = ???
+    override def trace(msg: => String): F[Unit] = ???
+    def trace(ctx: (String, String)*)(msg: => String): F[Unit] = ???
+
+    override def debug(t: Throwable)(msg: => String): F[Unit] = ???
+    override def debug(msg: => String): F[Unit] = ???
+    def debug(ctx: (String, String)*)(msg: => String): F[Unit] = ???
+
+    override def info(t: Throwable)(msg: => String): F[Unit] = ???
+    override def info(msg: => String): F[Unit] = ???
+    def info(ctx: (String, String)*)(msg: => String): F[Unit] = ???
+
+    override def warn(t: Throwable)(msg: => String): F[Unit] = ???
+    override def warn(msg: => String): F[Unit] = ???
+    def warn(ctx: (String, String)*)(msg: => String): F[Unit] = ???
+
+    override def error(t: Throwable)(msg: => String): F[Unit] = ???
+    override def error(msg: => String): F[Unit] = ???
+    def error(ctx: (String, String)*)(msg: => String): F[Unit] = ???
   }
 }
+
+final class Slf4jLogger[F[_]: Sync](val logger: JLogger) extends Slf4jLogger.Slf4jLoggerDummyMacro[F] {
+  val F: Sync[F] = Sync[F]
+  @inline override def isTraceEnabled: F[Boolean] = F.delay(logger.isTraceEnabled)
+
+  @inline override def isDebugEnabled: F[Boolean] = F.delay(logger.isDebugEnabled)
+
+  @inline override def isInfoEnabled: F[Boolean] = F.delay(logger.isInfoEnabled)
+
+  @inline override def isWarnEnabled: F[Boolean] = F.delay(logger.isWarnEnabled)
+
+  @inline override def isErrorEnabled: F[Boolean] = F.delay(logger.isErrorEnabled)
+
+  import LoggerMacros._
+
+  override def trace(t: Throwable)(msg: => String): F[Unit] = macro traceTM[F]
+  override def trace(msg: => String): F[Unit] = macro traceM[F]
+  override def trace(ctx: (String, String)*)(msg: => String): F[Unit] = macro traceCM[F]
+
+  override def debug(t: Throwable)(msg: => String): F[Unit] = macro debugTM[F]
+  override def debug(msg: => String): F[Unit] = macro debugM[F]
+  override def debug(ctx: (String, String)*)(msg: => String): F[Unit] = macro debugCM[F]
+
+  override def info(t: Throwable)(msg: => String): F[Unit] = macro infoTM[F]
+  override def info(msg: => String): F[Unit] = macro infoM[F]
+  override def info(ctx: (String, String)*)(msg: => String): F[Unit] = macro infoCM[F]
+
+  override def warn(t: Throwable)(msg: => String): F[Unit] = macro warnTM[F]
+  override def warn(msg: => String): F[Unit] = macro warnM[F]
+  override def warn(ctx: (String, String)*)(msg: => String): F[Unit] = macro warnCM[F]
+
+  override def error(t: Throwable)(msg: => String): F[Unit] = macro errorTM[F]
+  override def error(msg: => String): F[Unit] = macro errorM[F]
+  override def error(ctx: (String, String)*)(msg: => String): F[Unit] = macro errorCM[F]
+
+}
+

--- a/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/logLevels.scala
+++ b/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/logLevels.scala
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2013-2017 Sarah Gerweck
+ * see: https://github.com/Log4s/log4s
+ *
+ * Modifications copyright (C) 2018 Lorand Szakacs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.chrisdavenport.log4cats.slf4j
+
+/** A severity level that can be assigned to log statements. */
+sealed trait LogLevel {
+
+  /** The name of this log level. It is spelled with initial capitals */
+  def name: String = this.toString
+
+  /** The name of the SLF4J method that does logging at this level */
+  private[slf4j] def methodName = name.toLowerCase
+}
+
+object LogLevel {
+
+  def forName(name: String): LogLevel = {
+    name.toLowerCase match {
+      case "trace" => Trace
+      case "debug" => Debug
+      case "info" => Info
+      case "warn" => Warn
+      case "error" => Error
+      case _ =>
+        throw new IllegalArgumentException(s"No log level named $name")
+    }
+  }
+}
+
+/** The highest logging severity. This generally indicates an
+ * application or system error that causes undesired outcomes.
+ * An error generally indicates a bug or an environment
+ * problem that warrants some kind of immediate intervention.
+ */
+case object Error extends LogLevel
+
+/** Generally indicates something is not expected but the system is
+ * able to continue operating. This generally indicates a bug or
+ * environment problem that does not require urgent intervention.
+ */
+case object Warn extends LogLevel
+
+/** Indicates normal high-level activity. Generally a single user– or
+ * system-initiated activity will trigger one or two info-level statements.
+ * (E.g., one when starting and one when finishing for complex requests.)
+ */
+case object Info extends LogLevel
+
+/** Log statements that provide the ability to trace the progress and
+ * behavior involved in tracking a single activity. These are useful for
+ * debugging general issues, identifying how modules are interacting, etc.
+ */
+case object Debug extends LogLevel
+
+/** Highly localized log statements useful for tracking the decisions made
+ * inside a single unit of code. These may occur at a very high frequency.
+ */
+case object Trace extends LogLevel


### PR DESCRIPTION
Rewrote the `slf4j` module to use the same macro-based implementation as [iolog4s](iolog4s: https://iolog4s.github.io/iolog4s/)

One (big) problem tough. Macros  [cannot expand if they're hidden behind abstract methods](https://github.com/scala/scala/commit/ef979c02da887b7c56bc1da9c4eb888e92af570f) 😢. Which makes sense, but I never thought of, or ran into, the problem until now.

So the solution I stumbled upon is some sort of weird, super hacky, behind the scenes compromise. Have a look at this program:
```scala
object Main extends App {
  import io.chrisdavenport.log4cats.Logger
  import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
  import cats.effect.IO

  val slf4jL: Slf4jLogger[IO] = Slf4jLogger.create[IO]
  val logger: Logger[IO] = slf4jL

  val app = for {
    _ <- logger.info("non-macro-based info <=> old log4cats")
    _ <- slf4jL.info("macro-based info     <=> iolog4s")
    _ <- slf4jL.info("silver-lining" -> "we also have @oleg-py's MDC")(
      "macro-based info     <=> iolog4s — YEY! no runtime crash"
    )
  } yield ()

  app.unsafeRunSync()
}
```
When the user references the logger through the `Slf4jLogger[F]` interface they get something equivalent to macro-based `iolog4s`.  When they want to switch to the more abstract algebra of `Logger[F]` to write their own boilerplate saving algebra they lose macro-based optimization and they get something equivalent to the current `log4cats` implementation. This sounds super unorthodox and to be frowned upon from a pure FP perspective, but it kinda works without breaking stuff 🤷‍♂️ 

I created this PR as a starting point for a discussion on how to proceed. I'll keep hacking at it, maybe I find something better.

No longer relevant after second commit:
----
~~Thus, referencing a logger through its nice algebra defined in `io.chrisdavenport.log4cats.Logger[F]` is impossible. You always have to reference it through the subclass `io.chrisdavenport.log4cats.slf4j.Slf4jLogger[F]` which implements `Logger[F]`, but this would become very dangerous very quickly.

```
object Main extends App {

  import io.chrisdavenport.log4cats.Logger
  import io.chrisdavenport.log4cats.slf4j.Slf4jLogger

  import cats.effect.IO

  //attempting to log something fails at runtime with ???
  val logger: Logger[IO] = Slf4jLogger.create[IO]
 
  //works properly
  //val logger: Slf4jLogger[IO] = Slf4jLogger.create[IO].asInstanceOf[Slf4jLogger[IO]]

  val app = for {
    _ <- logger.debug("--- debugging ---")
    _ <- logger.info("--- informing ---")
  } yield ()

  app.unsafeRunSync()

}
```

We can provide a trivial translation from `iolog4s` to the `Logger` interface, but not sure how useful that is. Since the utility of `iolog4s` derives from its macro based that saves a few captures of variables in closures and whatnot. And your current solution for working with a `sfl4j` backend is better for `log4cats` because it doesn't render the algebra of `Logger[F]` dangerous.~~

