### PR TITLE
Switch from MDC to StructuredLogger name

### DIFF
--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareMDCLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareMDCLogger.scala
@@ -1,3 +1,0 @@
-package io.chrisdavenport.log4cats
-
-trait SelfAwareMDCLogger[F[_]] extends SelfAwareLogger[F] with MDCLogger[F]

--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareStructuredLogger.scala
@@ -1,0 +1,3 @@
+package io.chrisdavenport.log4cats
+
+trait SelfAwareStructuredLogger[F[_]] extends SelfAwareLogger[F] with StructuredLogger[F]

--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/StructuredLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/StructuredLogger.scala
@@ -1,6 +1,6 @@
 package io.chrisdavenport.log4cats
 
-trait MDCLogger[F[_]] extends Logger[F] {
+trait StructuredLogger[F[_]] extends Logger[F] {
   def trace(ctx: (String, String)*)(msg: => String): F[Unit]
   def debug(ctx: (String, String)*)(msg: => String): F[Unit]
   def info(ctx: (String, String)*)(msg: => String): F[Unit]

--- a/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
@@ -19,7 +19,7 @@
 package io.chrisdavenport.log4cats.slf4j
 
 import cats.effect.Sync
-import io.chrisdavenport.log4cats.SelfAwareMDCLogger
+import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.internal._
 import org.slf4j.{Logger => JLogger}
 
@@ -27,32 +27,32 @@ import language.experimental.macros
 
 object Slf4jLogger {
 
-  def create[F[_]: Sync]: F[SelfAwareMDCLogger[F]] =
+  def create[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] =
     Sync[F].delay(unsafeCreate)
 
-  def fromName[F[_]: Sync](name: String): F[SelfAwareMDCLogger[F]] =
+  def fromName[F[_]: Sync](name: String): F[SelfAwareStructuredLogger[F]] =
     Sync[F].delay(unsafeFromName(name))
 
-  def fromClass[F[_]: Sync](clazz: Class[_]): F[SelfAwareMDCLogger[F]] = 
+  def fromClass[F[_]: Sync](clazz: Class[_]): F[SelfAwareStructuredLogger[F]] = 
     Sync[F].delay(unsafeFromClass(clazz))
 
-  def fromSlf4j[F[_]: Sync](logger: JLogger): F[SelfAwareMDCLogger[F]] = 
+  def fromSlf4j[F[_]: Sync](logger: JLogger): F[SelfAwareStructuredLogger[F]] = 
     Sync[F].delay(unsafeFromSlf4j(logger))
 
-  def unsafeCreate[F[_]: Sync]: SelfAwareMDCLogger[F] = 
+  def unsafeCreate[F[_]: Sync]: SelfAwareStructuredLogger[F] = 
     macro LoggerMacros.getLoggerImpl[F[_]]
 
-  def unsafeFromName[F[_]: Sync](name: String): SelfAwareMDCLogger[F] =
+  def unsafeFromName[F[_]: Sync](name: String): SelfAwareStructuredLogger[F] =
     fromSlf4jLogger(new Slf4jLoggerInternal[F](org.slf4j.LoggerFactory.getLogger(name)))
 
-  def unsafeFromClass[F[_]: Sync](clazz: Class[_]): SelfAwareMDCLogger[F] =
+  def unsafeFromClass[F[_]: Sync](clazz: Class[_]): SelfAwareStructuredLogger[F] =
     fromSlf4jLogger(new Slf4jLoggerInternal[F](org.slf4j.LoggerFactory.getLogger(clazz)))
 
-  def unsafeFromSlf4j[F[_]: Sync](logger: JLogger): SelfAwareMDCLogger[F] =
+  def unsafeFromSlf4j[F[_]: Sync](logger: JLogger): SelfAwareStructuredLogger[F] =
     fromSlf4jLogger(new Slf4jLoggerInternal[F](logger))
 
-  private def fromSlf4jLogger[F[_]: Sync](s: Slf4jLoggerInternal[F]): SelfAwareMDCLogger[F] = 
-    new SelfAwareMDCLogger[F] {
+  private def fromSlf4jLogger[F[_]: Sync](s: Slf4jLoggerInternal[F]): SelfAwareStructuredLogger[F] = 
+    new SelfAwareStructuredLogger[F] {
       @inline override def isTraceEnabled: F[Boolean] = s.isTraceEnabled
       @inline override def isDebugEnabled: F[Boolean] = s.isDebugEnabled
       @inline override def isInfoEnabled: F[Boolean] = s.isInfoEnabled


### PR DESCRIPTION
Just a name change as MDC is something more specific, as this takes a context, not necessarily using injection, and applies it to the log messages. 