### PR TITLE
Fix Slf4jLogger.create

### DIFF
--- a/cats/slf4j-internal/src/main/scala/io/chrisdavenport/log4cats/slf4j/internal/Slf4jLoggerInternal.scala
+++ b/cats/slf4j-internal/src/main/scala/io/chrisdavenport/log4cats/slf4j/internal/Slf4jLoggerInternal.scala
@@ -29,7 +29,7 @@ private[slf4j] final class Slf4jLoggerInternal[F[_]](val logger: JLogger)(implic
 
   @inline def isErrorEnabled: F[Boolean] = F.delay(logger.isErrorEnabled)
 
-  import LoggerMacros._
+  import ReflectiveLogMacros._
 
   // Internal Methods To Not Run into Macro Abstract implementation issues.
   def internalTraceTM(t: Throwable)(msg: => String): F[Unit] = macro traceTM[F]

--- a/cats/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
+++ b/cats/slf4j/src/main/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLogger.scala
@@ -28,19 +28,19 @@ import language.experimental.macros
 object Slf4jLogger {
 
   def create[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] =
-    Sync[F].delay(unsafeCreate)
+    macro GetLoggerMacros.safeCreateImpl[F[_]]
 
   def fromName[F[_]: Sync](name: String): F[SelfAwareStructuredLogger[F]] =
     Sync[F].delay(unsafeFromName(name))
 
-  def fromClass[F[_]: Sync](clazz: Class[_]): F[SelfAwareStructuredLogger[F]] = 
+  def fromClass[F[_]: Sync](clazz: Class[_]): F[SelfAwareStructuredLogger[F]] =
     Sync[F].delay(unsafeFromClass(clazz))
 
-  def fromSlf4j[F[_]: Sync](logger: JLogger): F[SelfAwareStructuredLogger[F]] = 
+  def fromSlf4j[F[_]: Sync](logger: JLogger): F[SelfAwareStructuredLogger[F]] =
     Sync[F].delay(unsafeFromSlf4j(logger))
 
-  def unsafeCreate[F[_]: Sync]: SelfAwareStructuredLogger[F] = 
-    macro LoggerMacros.getLoggerImpl[F[_]]
+  def unsafeCreate[F[_]: Sync]: SelfAwareStructuredLogger[F] =
+    macro GetLoggerMacros.unsafeCreateImpl[F[_]]
 
   def unsafeFromName[F[_]: Sync](name: String): SelfAwareStructuredLogger[F] =
     fromSlf4jLogger(new Slf4jLoggerInternal[F](org.slf4j.LoggerFactory.getLogger(name)))

--- a/cats/slf4j/src/test/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
+++ b/cats/slf4j/src/test/scala/io/chrisdavenport/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
@@ -1,0 +1,33 @@
+package io.chrisdavenport.log4cats.slf4j
+
+import cats.effect.Sync
+import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
+
+
+class Slf4jLoggerSimpleClassMacroTest {
+  def loggerF[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] = Slf4jLogger.create[F]
+  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.unsafeCreate[F]
+}
+
+class Slf4jLoggerParameterizedClassMacroTest[A] {
+  def loggerF[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] = Slf4jLogger.create[F]
+  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.unsafeCreate[F]
+}
+
+class Slf4jLoggerHKTMacroTest[F[_]: Sync] {
+  def loggerF: F[SelfAwareStructuredLogger[F]] = Slf4jLogger.create[F]
+  def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.unsafeCreate[F]
+}
+
+object Slf4jLoggerModuleMacroTest {
+  def loggerF[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] = Slf4jLogger.create[F]
+  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.unsafeCreate[F]
+}
+
+class Slf4jLoggerOuterClassMacroTest {
+  class Slf4jLoggerInnerClassMacroTest {
+    def loggerF[F[_]: Sync]: F[SelfAwareStructuredLogger[F]] = Slf4jLogger.create[F]
+    def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.unsafeCreate[F]
+  }
+}
+


### PR DESCRIPTION
Fix `create` macros without code duplication and static annotations via a bundle.

I also added a few compilation tests. They don't check the name of the logger, but only validate quasiquotes.