### PR TITLE
test against OpenJDK 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 
 jdk:
   - oraclejdk8
+  - openjdk12
 
 before_install:
   - export PATH=${PATH}:./vendor/bundle


### PR DESCRIPTION
JDK 8 is good, but JDK 11 is latest LTS version, so it would be good to test against them both.
As JDK 12 doesn't introduce anything heavily incompatible with JDK 11, it seems good enough to test against latest JDK release.