### PR TITLE
upgrade scalaz-zio to 0.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val catsSettings = Seq(
 )
 
 lazy val scalazSettings = Seq(
-  libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.6.3"
+  libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.19"
 )
 
 lazy val releaseSettings = {

--- a/scalaz/log4s/src/main/scala/io/chrisdavenport/log4scalaz/log4s/Log4sLogger.scala
+++ b/scalaz/log4s/src/main/scala/io/chrisdavenport/log4scalaz/log4s/Log4sLogger.scala
@@ -2,50 +2,39 @@ package io.chrisdavenport.log4cats.log4s
 
 import io.chrisdavenport.log4cats._
 import org.log4s.{Logger => Base}
-import scalaz.zio.IO
+import scalaz.zio.UIO
 
 object Log4sLogger {
 
-  def createLocal = fromLog4s(org.log4s.getLogger)
-  def createByName(name: String) = fromLog4s(org.log4s.getLogger(name))
-  def createByClass(clazz: Class[_]) = fromLog4s(org.log4s.getLogger(clazz))
+  def createLocal: SelfAwareLogger[UIO] = fromLog4s(org.log4s.getLogger)
+  def createByName(name: String): SelfAwareLogger[UIO] = fromLog4s(org.log4s.getLogger(name))
+  def createByClass(clazz: Class[_]): SelfAwareLogger[UIO] = fromLog4s(org.log4s.getLogger(clazz))
 
-  def fromLog4s(logger: Base): SelfAwareLogger[IO[Nothing, ?]] =
-    new SelfAwareLogger[IO[Nothing, ?]] {
-      override def isTraceEnabled: IO[Nothing, Boolean] =
-        IO.sync(logger.isTraceEnabled)
-      override def isDebugEnabled: IO[Nothing, Boolean] =
-        IO.sync(logger.isDebugEnabled)
-      override def isInfoEnabled: IO[Nothing, Boolean] =
-        IO.sync(logger.isInfoEnabled)
-      override def isWarnEnabled: IO[Nothing, Boolean] =
-        IO.sync(logger.isWarnEnabled)
-      override def isErrorEnabled: IO[Nothing, Boolean] =
-        IO.sync(logger.isErrorEnabled)
+  def fromLog4s(logger: Base): SelfAwareLogger[UIO] = new SelfAwareLogger[UIO] {
+    override def isTraceEnabled: UIO[Boolean] = UIO.apply(logger.isTraceEnabled)
+    override def isDebugEnabled: UIO[Boolean] = UIO.apply(logger.isDebugEnabled)
+    override def isInfoEnabled: UIO[Boolean] = UIO.apply(logger.isInfoEnabled)
+    override def isWarnEnabled: UIO[Boolean] = UIO.apply(logger.isWarnEnabled)
+    override def isErrorEnabled: UIO[Boolean] = UIO.apply(logger.isErrorEnabled)
 
-      override def error(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.error(message))
-      override def error(t: Throwable)(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.error(t)(message))
+    override def error(message: => String): UIO[Unit] = UIO.apply(logger.error(message))
+    override def error(t: Throwable)(message: => String): UIO[Unit] =
+      UIO.apply(logger.error(t)(message))
 
-      override def warn(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.warn(message))
-      override def warn(t: Throwable)(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.warn(t)(message))
+    override def warn(message: => String): UIO[Unit] = UIO.apply(logger.warn(message))
+    override def warn(t: Throwable)(message: => String): UIO[Unit] =
+      UIO.apply(logger.warn(t)(message))
 
-      override def info(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.info(message))
-      override def info(t: Throwable)(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.info(t)(message))
+    override def info(message: => String): UIO[Unit] = UIO.apply(logger.info(message))
+    override def info(t: Throwable)(message: => String): UIO[Unit] =
+      UIO.apply(logger.info(t)(message))
 
-      override def debug(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.debug(message))
-      override def debug(t: Throwable)(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.debug(t)(message))
+    override def debug(message: => String): UIO[Unit] = UIO.apply(logger.debug(message))
+    override def debug(t: Throwable)(message: => String): UIO[Unit] =
+      UIO.apply(logger.debug(t)(message))
 
-      override def trace(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.trace(message))
-      override def trace(t: Throwable)(message: => String): IO[Nothing, Unit] =
-        IO.sync(logger.trace(t)(message))
-    }
+    override def trace(message: => String): UIO[Unit] = UIO.apply(logger.trace(message))
+    override def trace(t: Throwable)(message: => String): UIO[Unit] =
+      UIO.apply(logger.trace(t)(message))
+  }
 }


### PR DESCRIPTION
~I based in on top of #162 to minimize conflicts~ — now rebased on top of `master`.

- [x] newest zio version comes with out of the box alias and "companion object", using that as the effect type:  `type UIO[+A] = ZIO[Any, Nothing, A]`