### PR TITLE
Add ApplicativeLocal and FunctorTell loggers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbtcrossproject.{crossProject, CrossType}
 val catsV = "2.0.0"
 val catsEffectV = "2.0.0"
+val catsMtlV = "0.7.0"
 val slf4jV = "1.7.28"
 val specs2V = "4.7.1"
 
@@ -23,7 +24,7 @@ lazy val docs = project.in(file("docs"))
   .settings(commonSettings, micrositeSettings)
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(TutPlugin)
-  .dependsOn(slf4j)
+  .dependsOn(slf4j, mtlJVM)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform).in(file("core"))
   .settings(commonSettings, releaseSettings, mimaSettings)
@@ -72,6 +73,17 @@ lazy val slf4j = project
     )
   )
 
+lazy val mtl = crossProject(JSPlatform, JVMPlatform)
+  .in(file("mtl"))
+  .settings(commonSettings, releaseSettings, mimaSettings)
+  .dependsOn(core)
+  .settings(
+    name := "log4cats-mtl",
+    libraryDependencies += "org.typelevel" %% "cats-mtl-core" % catsMtlV
+  )
+
+lazy val mtlJVM = mtl.jvm
+lazy val mtlJS  = mtl.js
 
 lazy val contributors = Seq(
   "ChristopherDavenport" -> "Christopher Davenport",

--- a/mtl/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/ApplicativeAskLogger.scala
+++ b/mtl/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/ApplicativeAskLogger.scala
@@ -1,0 +1,103 @@
+package io.chrisdavenport.log4cats.mtl
+
+import cats.FlatMap
+import cats.mtl.ApplicativeAsk
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
+
+object ApplicativeAskLogger {
+
+  def unsafeCreate[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+      logger: SelfAwareStructuredLogger[F]
+  ): SelfAwareStructuredLogger[F] =
+    new ApplicativeAskLogger(logger)
+
+  def create[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+      logger: F[SelfAwareStructuredLogger[F]]
+  ): F[SelfAwareStructuredLogger[F]] =
+    logger.map(v => new ApplicativeAskLogger(v))
+
+}
+
+final class ApplicativeAskLogger[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+    underlying: SelfAwareStructuredLogger[F]
+) extends SelfAwareStructuredLogger[F] {
+
+  override def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(ctx ++ local)(msg))
+
+  override def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(ctx ++ local, t)(msg))
+
+  override def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(ctx ++ local)(msg))
+
+  override def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(ctx ++ local, t)(msg))
+
+  override def info(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(ctx ++ local)(msg))
+
+  override def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(ctx ++ local, t)(msg))
+
+  override def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(ctx ++ local)(msg))
+
+  override def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(ctx ++ local, t)(msg))
+
+  override def error(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(ctx ++ local)(msg))
+
+  override def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(ctx ++ local, t)(msg))
+
+  override def isTraceEnabled: F[Boolean] = underlying.isTraceEnabled
+  override def isDebugEnabled: F[Boolean] = underlying.isDebugEnabled
+  override def isInfoEnabled: F[Boolean] = underlying.isInfoEnabled
+  override def isWarnEnabled: F[Boolean] = underlying.isWarnEnabled
+  override def isErrorEnabled: F[Boolean] = underlying.isErrorEnabled
+
+  override def error(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(local)(message))
+
+  override def warn(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(local)(message))
+
+  override def info(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(local)(message))
+
+  override def debug(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(local)(message))
+
+  override def trace(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(local)(message))
+
+  override def error(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(local, t)(message))
+
+  override def warn(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(local, t)(message))
+
+  override def info(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(local, t)(message))
+
+  override def debug(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(local, t)(message))
+
+  override def trace(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(local, t)(message))
+
+  @inline private def withLocalCtx[B](f: Map[String, String] => F[B]): F[B] =
+    ApplicativeAsk.ask.flatMap(a => f(CtxEncoder[A].encode(a)))
+}
+
+trait CtxEncoder[A] {
+  def encode(value: A): Map[String, String]
+}
+
+object CtxEncoder {
+  def apply[A](implicit ev: CtxEncoder[A]): CtxEncoder[A] = ev
+}

--- a/mtl/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/FunctorTellLogger.scala
+++ b/mtl/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/FunctorTellLogger.scala
@@ -1,0 +1,71 @@
+package io.chrisdavenport.log4cats.mtl
+
+import cats.Applicative
+import cats.mtl.FunctorTell
+import cats.syntax.applicative._
+import cats.syntax.option._
+import io.chrisdavenport.log4cats.SelfAwareLogger
+import io.chrisdavenport.log4cats.extras.{LogLevel, LogMessage}
+
+object FunctorTellLogger {
+
+  def apply[F[_]: Applicative: FunctorTell[?[_], G[LogMessage]], G[_]: Applicative](
+      traceEnabled: Boolean = true,
+      debugEnabled: Boolean = true,
+      infoEnabled: Boolean = true,
+      warnEnabled: Boolean = true,
+      errorEnabled: Boolean = true
+  ): SelfAwareLogger[F] =
+    new FunctorTellLogger[F, G](traceEnabled, debugEnabled, infoEnabled, warnEnabled, errorEnabled)
+
+}
+
+final class FunctorTellLogger[F[_]: Applicative, G[_]: Applicative](
+    traceEnabled: Boolean = true,
+    debugEnabled: Boolean = true,
+    infoEnabled: Boolean = true,
+    warnEnabled: Boolean = true,
+    errorEnabled: Boolean = true
+)(implicit FT: FunctorTell[F, G[LogMessage]])
+    extends SelfAwareLogger[F] {
+
+  override def isTraceEnabled: F[Boolean] = traceEnabled.pure[F]
+  override def isDebugEnabled: F[Boolean] = debugEnabled.pure[F]
+  override def isInfoEnabled: F[Boolean] = infoEnabled.pure[F]
+  override def isWarnEnabled: F[Boolean] = warnEnabled.pure[F]
+  override def isErrorEnabled: F[Boolean] = errorEnabled.pure[F]
+
+  override def trace(t: Throwable)(message: => String): F[Unit] =
+    build(traceEnabled, LogLevel.Trace, t.some, message)
+  override def trace(message: => String): F[Unit] =
+    build(traceEnabled, LogLevel.Trace, None, message)
+
+  override def debug(t: Throwable)(message: => String): F[Unit] =
+    build(debugEnabled, LogLevel.Debug, t.some, message)
+  override def debug(message: => String): F[Unit] =
+    build(debugEnabled, LogLevel.Debug, None, message)
+
+  override def info(t: Throwable)(message: => String): F[Unit] =
+    build(infoEnabled, LogLevel.Info, t.some, message)
+  override def info(message: => String): F[Unit] =
+    build(infoEnabled, LogLevel.Info, None, message)
+
+  override def warn(t: Throwable)(message: => String): F[Unit] =
+    build(warnEnabled, LogLevel.Warn, t.some, message)
+  override def warn(message: => String): F[Unit] =
+    build(warnEnabled, LogLevel.Warn, None, message)
+
+  override def error(t: Throwable)(message: => String): F[Unit] =
+    build(errorEnabled, LogLevel.Error, t.some, message)
+  override def error(message: => String): F[Unit] =
+    build(errorEnabled, LogLevel.Error, None, message)
+
+  @inline private def build(
+      enabled: Boolean,
+      level: LogLevel,
+      t: Option[Throwable],
+      message: => String
+  ): F[Unit] =
+    FT.tell(LogMessage(level, t, message).pure[G]).whenA(enabled)
+
+}


### PR DESCRIPTION
This PR adds two new loggers:
1) A logger that uses a value of `cast.mtl.ApplicativeLocal` as an additional MDC;
2) A logger that writes `LogMessage` entries into effect context using `cats.mtl.FunctorTell`;

These changes related to the https://github.com/ChristopherDavenport/log4cats/issues/143. 
 