### PR TITLE
Log4Cats: Backport some API methods from newer versions.

### DIFF
--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/Logger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/Logger.scala
@@ -8,16 +8,17 @@ trait Logger[F[_]] extends MessageLogger[F] with ErrorLogger[F] {
 object Logger {
   def apply[F[_]](implicit ev: Logger[F]) = ev
 
-  private def withModifiedString[F[_]](l: Logger[F], f: String => String): Logger[F] = new Logger[F]{
-    def error(message: => String): F[Unit] = l.error(f(message))
-    def error(t: Throwable)(message: => String): F[Unit] = l.error(t)(f(message))
-    def warn(message: => String): F[Unit] = l.warn(f(message))
-    def warn(t: Throwable)(message: => String): F[Unit] = l.warn(t)(f(message))
-    def info(message: => String): F[Unit] = l.info(f(message))
-    def info(t: Throwable)(message: => String): F[Unit] = l.info(t)(f(message))
-    def debug(message: => String): F[Unit] = l.debug(f(message))
-    def debug(t: Throwable)(message: => String): F[Unit] = l.debug(t)(f(message))
-    def trace(message: => String): F[Unit] = l.trace(f(message))
-    def trace(t: Throwable)(message: => String): F[Unit] = l.trace(t)(f(message))
-  }
+  private def withModifiedString[F[_]](l: Logger[F], f: String => String): Logger[F] =
+    new Logger[F] {
+      def error(message: => String): F[Unit] = l.error(f(message))
+      def error(t: Throwable)(message: => String): F[Unit] = l.error(t)(f(message))
+      def warn(message: => String): F[Unit] = l.warn(f(message))
+      def warn(t: Throwable)(message: => String): F[Unit] = l.warn(t)(f(message))
+      def info(message: => String): F[Unit] = l.info(f(message))
+      def info(t: Throwable)(message: => String): F[Unit] = l.info(t)(f(message))
+      def debug(message: => String): F[Unit] = l.debug(f(message))
+      def debug(t: Throwable)(message: => String): F[Unit] = l.debug(t)(f(message))
+      def trace(message: => String): F[Unit] = l.trace(f(message))
+      def trace(t: Throwable)(message: => String): F[Unit] = l.trace(t)(f(message))
+    }
 }

--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareLogger.scala
@@ -3,7 +3,7 @@ package io.chrisdavenport.log4cats
 trait SelfAwareLogger[F[_]] extends Logger[F] {
   def isTraceEnabled: F[Boolean]
   def isDebugEnabled: F[Boolean]
-  def isInfoEnabled: F[Boolean] 
+  def isInfoEnabled: F[Boolean]
   def isWarnEnabled: F[Boolean]
   def isErrorEnabled: F[Boolean]
 }

--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/SelfAwareStructuredLogger.scala
@@ -1,7 +1,64 @@
 package io.chrisdavenport.log4cats
 
+import cats._
+
 trait SelfAwareStructuredLogger[F[_]] extends SelfAwareLogger[F] with StructuredLogger[F]
 
 object SelfAwareStructuredLogger {
   def apply[F[_]](implicit ev: SelfAwareStructuredLogger[F]): SelfAwareStructuredLogger[F] = ev
+
+  def withContext[F[_]](
+      sl: SelfAwareStructuredLogger[F]
+  )(ctx: Map[String, String]): SelfAwareStructuredLogger[F] =
+    new ExtraContextSelfAwareStructuredLogger[F](sl)(ctx)
+
+  private class ExtraContextSelfAwareStructuredLogger[F[_]](sl: SelfAwareStructuredLogger[F])(
+      ctx: Map[String, String]
+  ) extends SelfAwareStructuredLogger[F] {
+    private val outer = ctx
+    def error(message: => String): F[Unit] = sl.error(outer)(message)
+    def warn(message: => String): F[Unit] = sl.warn(outer)(message)
+    def info(message: => String): F[Unit] = sl.info(outer)(message)
+    def debug(message: => String): F[Unit] = sl.debug(outer)(message)
+    def trace(message: => String): F[Unit] = sl.trace(outer)(message)
+    def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.trace(outer ++ ctx)(msg)
+    def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.debug(outer ++ ctx)(msg)
+    def info(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.info(outer ++ ctx)(msg)
+    def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.warn(outer ++ ctx)(msg)
+    def error(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.error(outer ++ ctx)(msg)
+
+    def isTraceEnabled: F[Boolean] = sl.isTraceEnabled
+    def isDebugEnabled: F[Boolean] = sl.isDebugEnabled
+    def isInfoEnabled: F[Boolean] = sl.isInfoEnabled
+    def isWarnEnabled: F[Boolean] = sl.isWarnEnabled
+    def isErrorEnabled: F[Boolean] = sl.isErrorEnabled
+
+    def error(t: Throwable)(message: => String): F[Unit] =
+      sl.error(outer, t)(message)
+    def warn(t: Throwable)(message: => String): F[Unit] =
+      sl.warn(outer, t)(message)
+    def info(t: Throwable)(message: => String): F[Unit] =
+      sl.info(outer, t)(message)
+    def debug(t: Throwable)(message: => String): F[Unit] =
+      sl.debug(outer, t)(message)
+    def trace(t: Throwable)(message: => String): F[Unit] =
+      sl.trace(outer, t)(message)
+
+    def error(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.error(outer ++ ctx, t)(message)
+    def warn(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.warn(outer ++ ctx, t)(message)
+    def info(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.info(outer ++ ctx, t)(message)
+    def debug(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.debug(outer ++ ctx, t)(message)
+    def trace(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.trace(outer ++ ctx, t)(message)
+  }
+
 }

--- a/core/shared/src/main/scala/io/chrisdavenport/log4cats/StructuredLogger.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/log4cats/StructuredLogger.scala
@@ -1,6 +1,17 @@
 package io.chrisdavenport.log4cats
 
 trait StructuredLogger[F[_]] extends Logger[F] {
+  def trace(ctx: Map[String, String])(msg: => String): F[Unit]
+  def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit]
+  def debug(ctx: Map[String, String])(msg: => String): F[Unit]
+  def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit]
+  def info(ctx: Map[String, String])(msg: => String): F[Unit]
+  def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit]
+  def warn(ctx: Map[String, String])(msg: => String): F[Unit]
+  def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit]
+  def error(ctx: Map[String, String])(msg: => String): F[Unit]
+  def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit]
+
   def trace(ctx: (String, String)*)(msg: => String): F[Unit]
   def debug(ctx: (String, String)*)(msg: => String): F[Unit]
   def info(ctx: (String, String)*)(msg: => String): F[Unit]
@@ -8,7 +19,7 @@ trait StructuredLogger[F[_]] extends Logger[F] {
   def error(ctx: (String, String)*)(msg: => String): F[Unit]
 }
 
-object StructuredLogger{
+object StructuredLogger {
   def apply[F[_]](implicit ev: StructuredLogger[F]): StructuredLogger[F] = ev
 
   def withContext[F[_]](sl: StructuredLogger[F])(ctx: (String, String)*): MessageLogger[F] =
@@ -19,4 +30,51 @@ object StructuredLogger{
       def debug(message: => String): F[Unit] = sl.debug(ctx:_*)(message)
       def trace(message: => String): F[Unit] = sl.trace(ctx:_*)(message)
     }
+
+  def withContext[F[_]](sl: StructuredLogger[F])(ctx: Map[String, String]): StructuredLogger[F] =
+    new ExtraContextStructuredLogger[F](sl)(ctx)
+
+  private class ExtraContextStructuredLogger[F[_]](sl: StructuredLogger[F])(
+      ctx: Map[String, String]
+  ) extends StructuredLogger[F] {
+    private val outer = ctx
+    def error(message: => String): F[Unit] = sl.error(outer)(message)
+    def warn(message: => String): F[Unit] = sl.warn(outer)(message)
+    def info(message: => String): F[Unit] = sl.info(outer)(message)
+    def debug(message: => String): F[Unit] = sl.debug(outer)(message)
+    def trace(message: => String): F[Unit] = sl.trace(outer)(message)
+    def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.trace(outer ++ ctx)(msg)
+    def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.debug(outer ++ ctx)(msg)
+    def info(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.info(outer ++ ctx)(msg)
+    def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.warn(outer ++ ctx)(msg)
+    def error(ctx: Map[String, String])(msg: => String): F[Unit] =
+      sl.error(outer ++ ctx)(msg)
+
+    def error(t: Throwable)(message: => String): F[Unit] =
+      sl.error(outer, t)(message)
+    def warn(t: Throwable)(message: => String): F[Unit] =
+      sl.warn(outer, t)(message)
+    def info(t: Throwable)(message: => String): F[Unit] =
+      sl.info(outer, t)(message)
+    def debug(t: Throwable)(message: => String): F[Unit] =
+      sl.debug(outer, t)(message)
+    def trace(t: Throwable)(message: => String): F[Unit] =
+      sl.trace(outer, t)(message)
+
+    def error(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.error(outer ++ ctx, t)(message)
+    def warn(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.warn(outer ++ ctx, t)(message)
+    def info(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.info(outer ++ ctx, t)(message)
+    def debug(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.debug(outer ++ ctx, t)(message)
+    def trace(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
+      sl.trace(outer ++ ctx, t)(message)
+  }
+
 }


### PR DESCRIPTION
We bring back from the future version (1.0.0) some of the methods that
already exist there, and which we can implement in current version.